### PR TITLE
Add ControlBuilder.Memory

### DIFF
--- a/src/core/PublicAPI.Unshipped.txt
+++ b/src/core/PublicAPI.Unshipped.txt
@@ -400,6 +400,7 @@ Vezel.Cathode.Text.Control.ControlBuilder.HorizontalTab() -> Vezel.Cathode.Text.
 Vezel.Cathode.Text.Control.ControlBuilder.InsertCharacters(int count) -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.InsertLines(int count) -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.LineFeed() -> Vezel.Cathode.Text.Control.ControlBuilder!
+Vezel.Cathode.Text.Control.ControlBuilder.Memory.get -> System.ReadOnlyMemory<char>
 Vezel.Cathode.Text.Control.ControlBuilder.MoveBufferDown(int count) -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.MoveBufferUp(int count) -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.MoveCursorDown(int count) -> Vezel.Cathode.Text.Control.ControlBuilder!
@@ -464,7 +465,6 @@ Vezel.Cathode.Text.Control.ControlBuilder.SetWorkingDirectory(System.Uri! uri) -
 Vezel.Cathode.Text.Control.ControlBuilder.SoftReset() -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.Space() -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.Span.get -> System.ReadOnlySpan<char>
-Vezel.Cathode.Text.Control.ControlBuilder.Memory.get -> System.ReadOnlyMemory<char>
 Vezel.Cathode.Text.Control.ControlBuilder.Substitute() -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.UnitSeparator() -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.VerticalTab() -> Vezel.Cathode.Text.Control.ControlBuilder!

--- a/src/core/PublicAPI.Unshipped.txt
+++ b/src/core/PublicAPI.Unshipped.txt
@@ -464,6 +464,7 @@ Vezel.Cathode.Text.Control.ControlBuilder.SetWorkingDirectory(System.Uri! uri) -
 Vezel.Cathode.Text.Control.ControlBuilder.SoftReset() -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.Space() -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.Span.get -> System.ReadOnlySpan<char>
+Vezel.Cathode.Text.Control.ControlBuilder.Memory.get -> System.ReadOnlyMemory<char>
 Vezel.Cathode.Text.Control.ControlBuilder.Substitute() -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.UnitSeparator() -> Vezel.Cathode.Text.Control.ControlBuilder!
 Vezel.Cathode.Text.Control.ControlBuilder.VerticalTab() -> Vezel.Cathode.Text.Control.ControlBuilder!

--- a/src/core/Text/Control/ControlBuilder.cs
+++ b/src/core/Text/Control/ControlBuilder.cs
@@ -119,6 +119,8 @@ public sealed class ControlBuilder
 
     public ReadOnlySpan<char> Span => _writer.WrittenSpan;
 
+    public ReadOnlyMemory<char> Memory => _writer.WrittenMemory;
+
     private static readonly CultureInfo _culture = CultureInfo.InvariantCulture;
 
     private readonly int _capacity;


### PR DESCRIPTION
`Span<>` isn't available inside of an async method, which makes it more difficult to use `ControlBuilder` without an alloc.

The underlying type is `ArrayBufferWriter<>`, which exports a `Memory`, so this change just exposes that API to `ControlBuilder` as well.